### PR TITLE
Bootstrapで全体的な見た目を調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,3 +30,11 @@ body {
   padding-top: 56px;
 }
 
+// フラッシュ
+.alert-notice {
+  @extend .alert-success;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,8 @@
  *= require_tree .
  *= require_self
  */
+@import "bootstrap/scss/bootstrap";
+
+$fa-font-path: '@fortawesome/fontawesome-free/webfonts';
+@import "@fortawesome/fontawesome-free/scss/fontawesome";
+@import "@fortawesome/fontawesome-free/scss/regular";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,8 +19,14 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 @import "@fortawesome/fontawesome-free/scss/fontawesome";
 @import "@fortawesome/fontawesome-free/scss/regular";
 
+// 共通
 .base-container {
-  @extend .container-xl;
+  @extend .container-fluid;
   max-width: var(--breakpoint-lg);
   padding: 30px 15px;
 }
+
+body {
+  padding-top: 56px;
+}
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,9 @@
 $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 @import "@fortawesome/fontawesome-free/scss/fontawesome";
 @import "@fortawesome/fontawesome-free/scss/regular";
+
+.base-container {
+  @extend .container-xl;
+  max-width: var(--breakpoint-lg);
+  padding: 30px 15px;
+}

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -2,7 +2,7 @@ class DocumentsController < ApplicationController
   before_action :set_document, only: %i[show edit update destroy]
 
   def index
-    @documents = Document.order(created_at: :asc)
+    @documents = Document.order(created_at: :desc)
   end
 
   def show

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,8 @@ import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
+import "bootstrap/dist/js/bootstrap"
+import "@fortawesome/fontawesome-free/js/all"
 
 Rails.start()
 Turbolinks.start()

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -1,13 +1,13 @@
 <%= form_with model:@document, local: true do |form| %>
-<div>
+<div class="form-group">
   <%= form.label :title, "タイトル" %>
-  <%= form.text_field :title %>
+  <%= form.text_field :title, class: "form-control", placeholder:"タイトルを入力してください" %>
 </div>
-<div>
+<div class="form-group">
   <%= form.label :body, "本文" %>
-  <%= form.text_area :body %>
+  <%= form.text_area :body, class: "form-control", placeholder:"本文を入力してください", rows: 10 %>
 </div>
 <div>
-  <%= form.submit botton_value %>
+  <%= form.submit botton_value, class: "btn btn-primary btn-block" %>
 <div>
 <% end %>

--- a/app/views/documents/_form.html.erb
+++ b/app/views/documents/_form.html.erb
@@ -1,13 +1,13 @@
 <%= form_with model:@document, local: true do |form| %>
-<div class="form-group">
-  <%= form.label :title, "タイトル" %>
-  <%= form.text_field :title, class: "form-control", placeholder:"タイトルを入力してください" %>
-</div>
-<div class="form-group">
-  <%= form.label :body, "本文" %>
-  <%= form.text_area :body, class: "form-control", placeholder:"本文を入力してください", rows: 10 %>
-</div>
-<div>
-  <%= form.submit botton_value, class: "btn btn-primary btn-block" %>
-<div>
+  <div class="form-group">
+    <%= form.label :title, "タイトル" %>
+    <%= form.text_field :title, class: "form-control", placeholder:"タイトルを入力してください" %>
+  </div>
+  <div class="form-group">
+    <%= form.label :body, "本文" %>
+    <%= form.text_area :body, class: "form-control", placeholder:"本文を入力してください", rows: 10 %>
+  </div>
+  <div>
+    <%= form.submit botton_value, class: "btn btn-primary btn-block" %>
+  <div>
 <% end %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,5 +1,5 @@
 <h1 class="text-center">記事詳細</h1>
-    <h6 div="text-right"><%= l @document.created_at %>に投稿
+<h6 div="text-right"><%= l @document.created_at %>に投稿
 <section class="card border-dark mt-5">
   <div class="card-header">
     <h4><%= @document.title %></h4>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,3 +1,10 @@
-<h1>記事詳細</h1>
-<p><%= @document.title %></p>
-<p><%= @document.body %></p>
+<h1 class="text-center">記事詳細</h1>
+    <h6 div="text-right"><%= l @document.created_at %>に投稿
+<section class="card border-dark mt-5">
+  <div class="card-header">
+    <h4><%= @document.title %></h4>
+  </div>
+  <div class="card-body">
+    <p class="card-text"><%= simple_format(h @document.body) %></p>
+  </div>
+</section>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,4 +1,7 @@
 <% flash.each do |flash_type, msg| %>
-  <p style="color: <%= flash_type == 'notice' ? 'green' : 'red' %>;"><%= msg %></p>
-  <hr>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
+  </div>
 <% end %>
+

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,12 +1,11 @@
 <nav class="navbar navbar-expand-sm navbar-dark fixed-top bg-info" >
-  <span class="navbar-brand">情報共有サイト</span>
+  <%= link_to "情報共有サイト", documents_path, class: "navbar-brand" %>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
   <div class="collapse navbar-collapse " id="navbarNavAltMarkup">
     <div class="navbar-nav ml-auto ">
       <% if user_signed_in? %>
-        <%= link_to "投稿一覧", documents_path, class: "nav-item nav-link active" %>
         <%= link_to "新規投稿", new_document_path, class: "nav-item nav-link active" %>
         <%= link_to "アカウント編集", edit_user_registration_path, class: "nav-item nav-link active" %>
         <%= link_to "ログアウト", destroy_user_session_path, class: "nav-item nav-link active", method: :delete, date: { confirm: "ログアウトしますか？" } %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,11 +1,21 @@
-  <% if user_signed_in? %>
-  <%= link_to "投稿一覧", documents_path %>
-  <%= link_to "新規投稿", new_document_path %>
-  <%= link_to "アカウント編集", edit_user_registration_path %>
-  <%= link_to "ログアウト", destroy_user_session_path, method: :delete, date: { confirm: "ログアウトしますか？" } %>
-  <%= "【ログイン中のメールアドレス】#{current_user.email}" %>
-  <% else %>
-  <%= link_to "新規登録", new_user_registration_path %>
-  <%= link_to "ログイン", new_user_session_path %>
-  <% end %>
-  <hr>
+<nav class="navbar navbar-expand-sm navbar-dark fixed-top bg-info" >
+  <span class="navbar-brand">情報共有サイト</span>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse " id="navbarNavAltMarkup">
+    <div class="navbar-nav ml-auto ">
+      <% if user_signed_in? %>
+        <%= link_to "投稿一覧", documents_path, class: "nav-item nav-link active" %>
+        <%= link_to "新規投稿", new_document_path, class: "nav-item nav-link active" %>
+        <%= link_to "アカウント編集", edit_user_registration_path, class: "nav-item nav-link active" %>
+        <%= link_to "ログアウト", destroy_user_session_path, class: "nav-item nav-link active", method: :delete, date: { confirm: "ログアウトしますか？" } %>
+        <%= "【ログイン中のメールアドレス】#{current_user.email}" %>
+      <% else %>
+        <%= link_to "新規登録", new_user_registration_path, class: "nav-item nav-link active" %>
+        <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
+      <% end %>
+      <hr>
+    </div>
+  </div>
+</nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>InformationShareSite</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -11,8 +11,14 @@
   </head>
 
   <body>
-    <%= render "layouts/header" %>
-    <%= render "layouts/flash" %>
-    <%= yield %>
+    <header>
+      <%= render "layouts/header" %>
+    </header>
+    <main>
+      <%= render "layouts/flash" %>
+      <div class="base-container">
+        <%= yield %>
+      </div>
+    </main>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -2,10 +2,14 @@
   "name": "information-share-site",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.15.4",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.0",
+    "bootstrap": "~4.5.1",
+    "jquery": "^3.6.0",
+    "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,6 +885,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-free@^5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz#ecda5712b61ac852c760d8b3c79c96adca5554e5"
+  integrity sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==
+
 "@npmcli/move-file@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.2.tgz#1a82c3e372f7cae9253eb66d72543d6b8685c674"
@@ -1490,6 +1495,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+bootstrap@~4.5.1:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.3.tgz#c6a72b355aaf323920be800246a6e4ef30997fe6"
+  integrity sha512-o9ppKQioXGqhw8Z7mah6KdTYpNQY//tipnkxppWhPbiSWdD+1raYsnhwEZjkTHYbGee4cVQ0Rx65EhOY/HNLcQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3760,6 +3770,11 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4718,6 +4733,11 @@ pnp-webpack-plugin@^1.6.4:
   integrity sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==
   dependencies:
     ts-pnp "^1.1.6"
+
+popper.js@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 portfinder@^1.0.26:
   version "1.0.28"


### PR DESCRIPTION
## 実装内容
- BootstrapとFontAwesomeの導入
- ヘッダー部分・記事一覧・新規投稿・編集・記事詳細の見た目修正
- フラッシュメッセージの見た目修正

## 実装画面
- 投稿一覧画面
<img width="1430" alt="スクリーンショット 2021-08-30 17 35 24" src="https://user-images.githubusercontent.com/72636397/131311265-cd54248e-d38e-4d10-aec6-261f5f450338.png">

- 新規投稿画面
<img width="1440" alt="スクリーンショット 2021-08-30 17 35 48" src="https://user-images.githubusercontent.com/72636397/131311288-05ce0445-e657-47a7-a7d0-80997d305b7a.png">

- 記事詳細画面
<img width="1438" alt="スクリーンショット 2021-08-30 17 36 05" src="https://user-images.githubusercontent.com/72636397/131311299-07c7f76f-69a2-433c-98ff-8f62b8704ced.png">