### PR TITLE
一覧画面のスタイル修正

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -7,9 +7,9 @@
         <h2><%= document.title %></h2>
       </td>
       <td>
-        <%= link_to "記事詳細", document %>
-        <%= link_to "記事編集", edit_document_path(document) %>
-        <%= link_to "削除", document, method: :delete, data: { confirm: "削除しますか?" } %>
+        <%= link_to "記事詳細", document, class: "btn btn-outline-primary btn-sm" %>
+        <%= link_to "記事編集", edit_document_path(document), class: "btn btn-outline-primary btn-sm" %>
+        <%= link_to "削除", document, method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-outline-primary btn-sm"  %>
          <hr>
       </td>
     <% end %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -4,11 +4,10 @@
     <% @documents.each do |document| %>
       <td>
         <%= l document.created_at %>に投稿
-        <h2><%= document.title %></h2>
+        <h3><%= link_to document.title, document, :style=>"color:black;" %></h3>
       </td>
       <td>
-        <%= link_to "記事詳細", document, class: "btn btn-outline-primary btn-sm" %>
-        <%= link_to "記事編集", edit_document_path(document), class: "btn btn-outline-primary btn-sm" %>
+        <%= link_to "編集", edit_document_path(document), class: "btn btn-outline-primary btn-sm" %>
         <%= link_to "削除", document, method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-outline-primary btn-sm"  %>
          <hr>
       </td>


### PR DESCRIPTION
## 実装内容
- 一覧画面の詳細・編集・削除リンクをボタンへ変更
- タイトルをクリックすると、詳細ページに遷移
- 詳細ページのリンク削除

## 実装画面
<img width="1438" alt="スクリーンショット 2021-09-04 17 07 00" src="https://user-images.githubusercontent.com/72636397/132087669-242de8ba-619e-42ab-bfdc-2de0cd374a77.png">
