### PR TITLE
ボタンの位置を調整

### DIFF
--- a/app/assets/stylesheets/documents.scss
+++ b/app/assets/stylesheets/documents.scss
@@ -1,3 +1,12 @@
 // Place all the styles related to the documents controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+.card-document {
+  margin-bottom: 10px;
+}
+
+.btn {
+  float: right;
+  margin: 5px;
+}

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -4,7 +4,13 @@
     <% @documents.each do |document| %>
       <td>
         <%= l document.created_at %>に投稿
-        <h3><%= link_to document.title, document, :style=>"color:black;" %></h3>
+        <h3>
+        <%= link_to document.title, document, :style=>"color:black;" %>
+        </h3>
+          <% if current_user.id == document.user_id %>
+            <%= link_to "削除", document, method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-danger btn-sm"  %>
+            <%= link_to "編集", edit_document_path(document), class: "btn btn-outline-primary  btn-sm" %>
+          <% end %>
           <p id="document-<%= document.id %>">
             <% if document.liked_by?(current_user) %>
               <%= render "like", document: document %>
@@ -12,11 +18,9 @@
               <%= render "dislike", document: document %>
             <% end %>
           </p>
+         <hr>
       </td>
       <td>
-        <%= link_to "編集", edit_document_path(document), class: "btn btn-outline-primary btn-sm" %>
-        <%= link_to "削除", document, method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-danger btn-sm"  %>
-         <hr>
       </td>
     <% end %>
   </div>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,6 +1,6 @@
 <h1 class="text-center">記事詳細</h1>
 <h6 div="text-right"><%= l @document.created_at %>に投稿
-<section class="card border-dark mt-5">
+<div class="card card-document border-dark mt-5">
   <div class="card-header">
     <h4><%= @document.title %></h4>
     <p id="document-<%= @document.id %>">
@@ -14,4 +14,11 @@
   <div class="card-body">
     <p class="card-text"><%= simple_format(h @document.body) %></p>
   </div>
-</section>
+</div>
+  <% if current_user.id == @document.user_id %>
+    <p>
+      <%= link_to "削除", document_path(@document), method: :delete, date: { confirm: "削除しますか？" }, class: "btn btn-danger btn-sm" %>
+      <%= link_to "編集", edit_document_path(@document), class: "btn btn-outline-primary btn-sm" %>
+    </p>
+  <% end %>
+  <p><%= link_to "戻る", documents_path, class: "btn btn-info active btn-block" %></p>


### PR DESCRIPTION
close #26 

## 実装内容
- 一覧画面の編集・削除ボタンの位置を右側に変更
- 詳細画面の編集・削除ボタンの位置を微調整
- ボタンのデザインを変更

## 実装画面
- 一覧画面
![スクリーンショット 2021-09-26 9 13 45](https://user-images.githubusercontent.com/72636397/134788958-f6bd8a6b-110f-467f-9e2a-1f3351274c50.png)

- 詳細画面
![スクリーンショット 2021-09-26 9 14 30](https://user-images.githubusercontent.com/72636397/134788968-f6928e9f-d2ce-49f2-9020-b27d0c7d9159.png)

