### PR TITLE
トップ画面の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,6 +28,9 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 
 body {
   padding-top: 56px;
+    font-family: Arial,
+    Helvetica,
+    sans-serif;
 }
 
 // フラッシュ

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -1,0 +1,99 @@
+
+body {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+
+.card-top {
+  padding-top: 90px;
+}
+
+.card-text {
+  line-height: 1.8;
+}
+
+.card-title {
+  font-weight: bold;
+}
+
+.btn-top {
+  font-size: 20px;
+  width: 185px;
+  height: 45px;
+  text-align: center;
+  padding: 7px;
+  background-color: #4270d3;
+  transition: all 0.5s ease;
+  float: right;
+}
+
+.btn-top:hover {
+  background-color: #8baefa;
+}
+
+.btn-redius {
+  color: #fff;
+  border-radius: 100vh;
+  box-sizing: border-box;
+}
+
+.text-white {
+  text-decoration: none;
+}
+
+.card-subtitle {
+  font-size: 1.6rem;
+  font-feature-settings: "pwid";
+  line-height: 1.5;
+}
+
+// ここから---------------------------------------------------------------------------------------
+// .main-container {
+//   display: flex;
+//   width: 1000px;
+//   padding-top: 150px;
+// }
+
+// .container-image {
+//   width: 500px;
+//   height: 400px;
+//   background-image: url(https://wp.notepm.jp/wp-content/uploads/2020/01/info-tool-3.jpg);
+//   background-size: contain;
+//   background-repeat: no-repeat;
+//   background-position: 20px 20px;
+// }
+
+
+
+// .text {
+//   font-size: 1.6rem;
+//   font-feature-settings: "pwid";
+//   line-height: 1.5;
+// }
+
+// .btn-top {
+//   font-size: 20px;
+//   width: 185px;
+//   height: 45px;
+//   text-align: center;
+//   padding: 7px;
+//   background-color: #4270d3;
+//   transition: all 0.5s ease;
+//   float: right;
+// }
+
+// .btn-top:hover {
+//   background-color: #8baefa;
+// }
+
+// .btn-redius {
+//   color: #fff;
+//   border-radius: 100vh;
+//   box-sizing: border-box;
+// }
+
+// .text-white {
+//   text-decoration: none;
+// }
+
+// ここまで--------------------------------------------------------------------------------

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,5 +1,6 @@
 class DocumentsController < ApplicationController
   before_action :set_document, only: %i[show edit update destroy]
+  before_action :authenticate_user!, only: [:index, :show]
   PER_PAGE = 5
 
   def index
@@ -39,5 +40,9 @@ class DocumentsController < ApplicationController
 
     def set_document
       @document = Document.find(params[:id])
+    end
+
+    def after_sign_out_path_for(resource)
+      document_path
     end
 end

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,0 +1,4 @@
+class TopController < ApplicationController
+  def index
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-sm navbar-dark fixed-top bg-info" >
-  <%= link_to "情報共有サイト", documents_path, class: "navbar-brand" %>
+  <%= link_to "情報共有サイト", top_index_path, class: "navbar-brand" %>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,0 +1,45 @@
+<div class="card-top">
+  <div class="row no-gutters">
+    <div class="col-md-6">
+      <div class="card-body">
+        <h1 class="card-title">情報共有サイト</h1>
+        <h3 class="card-subtitle">
+          養護教諭のための<br>
+          様々な情報を共有するサイト
+        </h3>
+        <p class="card-text ">
+          養護教諭の仕事のやり方や仕事に対する悩みを共有し、<br>
+          少しでも不安や悩みを解消出来ればと思い開発しました。
+        </p>
+        <div class="btn-top btn-redius">
+          <%= link_to "記事を見てみる", documents_path, class: "text-white text-decoration-none" %>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <%= image_tag "https://wp.notepm.jp/wp-content/uploads/2020/01/info-tool-3.jpg", size: "470x400", alt:"情報共有画像" %>
+    </div>
+  </div>
+</div>
+
+
+<!-- 修正前
+<div class="main-container">
+  <div class="container-paragraf">
+    <h1 class="top-title">情報共有サイト</h1>
+    <h3 class="text">
+      このサイトは養護教諭のための<br>
+      様々な情報を共有するサイトです。
+    </h3>
+    <p class="sentence">
+      普段の仕事の中で仕事のやり方や仕事に対する悩みを共有し、<br>
+      少しでも不安や悩みを解消出来ればと思い開発しました。
+    </p>
+    <div class="btn-top btn-redius">
+      <%= link_to "記事を見てみる", documents_path, class: "text-white text-decoration-none"%>
+    </div>
+  </div>
+  <div class="container-image">
+  </div>
+</div>
+-->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'top/index'
   devise_for :users
   root "documents#index"
   resources :documents do


### PR DESCRIPTION
close #28 
 
## 概要
- タイトルと本文を表示
- 一覧画面に遷移するボタンを作成


## 実装画面
<img width="1436" alt="スクリーンショット 2021-10-19 12 44 28" src="https://user-images.githubusercontent.com/72636397/137840503-bf5ad8f3-7559-48d9-a16a-1e6b8d7e1386.png">

