### PR TITLE
検索画面の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "devise-bootstrap-views", "~> 1.0"
 gem "devise-i18n"
 gem "kaminari", git: "https://github.com/kaminari/kaminari"
 gem "rails-i18n", "~> 6.0"
+gem "ransack"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,10 @@ GEM
       thor (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.6)
+    ransack (2.4.2)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -266,6 +270,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4)
   rails-i18n (~> 6.0)
+  ransack
   rubocop-rails
   sass-rails (>= 6)
   spring

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -61,3 +61,10 @@
   font-feature-settings: "pwid";
   line-height: 1.5;
 }
+
+// 検索機能
+
+.search-control {
+  margin-top: 30px;
+  text-align: center;
+}

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -4,7 +4,8 @@ class DocumentsController < ApplicationController
   PER_PAGE = 5
 
   def index
-    @documents = Document.includes(:user, :likes).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
+    @q = Document.ransack(params[:q])
+    @documents = @q.result.includes(:user, :likes).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
   end
 
   def show

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,4 +1,12 @@
 <h1 class="text-center">投稿一覧</h1>
+<div class="search-control">
+  <%= search_form_for @q do |f| %>
+    <%= f.label :title_cont, "検索" %>
+    <%= f.search_field :title_cont,  placeholder: "タイトルを入力" %>
+    <%= f.submit "検索" %>
+  <% end %>
+</div>
+
 <div class="container container-top">
   <div>
     <% @documents.each do |document| %>


### PR DESCRIPTION
close #33 

## 実装内容
- ransack gem のインストール
- 一覧画面に検索バーを表示

## 実装画面
<img width="1429" alt="スクリーンショット 2021-11-03 22 29 53" src="https://user-images.githubusercontent.com/72636397/140068920-ccc6608a-57be-4184-ab66-145530c08d4e.png">

